### PR TITLE
[ch25723] PSEA: Edit icon on Action Points should no longer be available if Status = "completed"

### DIFF
--- a/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-page.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-page.ts
@@ -150,7 +150,7 @@ export class FollowUpPage extends connect(store)(LitElement) {
 
   setRowActionsVisibility(item: GenericObject) {
     const isEditable = item && item.status !== 'completed';
-    return {showEdit: isEditable, showCopy: isEditable};
+    return {showEdit: isEditable, showCopy: true};
   }
 
   editActionPoint(event: GenericObject) {


### PR DESCRIPTION
[ch25723] PSEA: Edit icon on Action Points should no longer be available if Status = "completed"