### PR TITLE
[ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021

### DIFF
--- a/src_ts/components/pages/assessments/assessment-tab-pages/details/assessment-info.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/details/assessment-info.ts
@@ -105,7 +105,7 @@ export class AssessmentInfo extends connect(store)(PermissionsMixin(LitElement))
           <div class="col col-6">
             <etools-dropdown
               id="seaType"
-              label="PSEA Assessment Type"
+              label="Assessment Type"
               class="w100"
               .options="${this.assessment_types}"
               .selected="${this.assessment.assessment_type}"

--- a/src_ts/components/pages/assessments/assessment-tab-pages/details/assessment-info.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/details/assessment-info.ts
@@ -113,7 +113,9 @@ export class AssessmentInfo extends connect(store)(PermissionsMixin(LitElement))
               option-label="label"
               trigger-value-change-event
               @etools-selected-item-changed="${({detail}: CustomEvent) => {
-                this.assessment!.assessment_type = detail.selectedItem?.value;
+                if (detail.selectedItem) {
+                  this.assessment!.assessment_type = detail.selectedItem.value;
+                }
               }}"
               ?readonly="${this.isReadonly(this.editMode, this.assessment.permissions.edit.assessment_type)}"
               ?required="${this.assessment.permissions.required.assessment_type}"


### PR DESCRIPTION
[ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021