### PR TITLE
Staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,4 +78,3 @@ workflows:
                 - master
                 - staging
                 - develop
-                - circleci-tweak

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,14 +943,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/iron-test-helpers": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-test-helpers/-/iron-test-helpers-3.0.1.tgz",
-      "integrity": "sha512-2R7dnGcW2eg95i7LhYWWUO4AlAk6qXsPnKoyeN2R1t0km0ECMx0jjwqeLwCo8/7LwuVPZSiarI4DK7jyU7fJLQ==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/iron-validatable-behavior": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-validatable-behavior/-/iron-validatable-behavior-3.0.1.tgz",
@@ -1755,28 +1747,21 @@
       }
     },
     "@unicef-polymer/etools-ajax": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-ajax/-/etools-ajax-4.2.0.tgz",
-      "integrity": "sha512-eZsWQjElawijp5D9J3trx4yahsiCFKzjekvlAEfMhY1PJaEGB+lfqSufv6Avqm5Lb96w46D5M2CI4q//XYHVJA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-ajax/-/etools-ajax-4.3.4.tgz",
+      "integrity": "sha512-cLaqDZfrYQb/1+rnTCbEFxTRwHisWH1WTj4ndBDVzjuhA+J4L3pQNAHwwxXCTLbrHk69l38fW+8PnfE4hd8Wqw==",
       "requires": {
         "@polymer/iron-ajax": "^3.0.1",
         "@polymer/polymer": "^3.4.1",
-        "@unicef-polymer/etools-behaviors": "^3.0.4",
+        "@unicef-polymer/etools-behaviors": "^3.0.5",
         "@unicef-polymer/etools-dexie-caching": "^1.0.2",
-        "lodash": "^4.17.20"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": ">=4.17.21"
       }
     },
     "@unicef-polymer/etools-app-selector": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-app-selector/-/etools-app-selector-3.1.6.tgz",
-      "integrity": "sha512-de97balnnNFVUPnIEqesEBWpuEdjYEmFtEdtDpoZQOEoTI3mzQV2TKzKp2QrXJHzo2qa4LO7eCaCdouMW9FIbw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-app-selector/-/etools-app-selector-3.1.8.tgz",
+      "integrity": "sha512-kNkzUqnXf7txeTYAeFOEaQwRQqrWW7H2aRSaLJodWEeAZWWGyi0mOn+Hh57gjxOcuXnkQT+uo0B0uktoCv94qA==",
       "requires": {
         "@polymer/iron-collapse": "^3.0.0",
         "@polymer/paper-icon-button": "^3.0.0",
@@ -1785,9 +1770,9 @@
       }
     },
     "@unicef-polymer/etools-behaviors": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-behaviors/-/etools-behaviors-3.0.4.tgz",
-      "integrity": "sha512-XwnJUVJEimtcwhXrbh2CTmRFknVZqVdV8hzXNrRgJr1B8KHlviqP+rWtqwERlKufzJx2Rv4gfenpRpCcCSr/9w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-behaviors/-/etools-behaviors-3.0.5.tgz",
+      "integrity": "sha512-oUajpikDXRu5LgirH8aXnuV/EBZ13ES1Sy2P3BPISIctV2lKFYNsMSM117MyUyGT6JvgLe7EjgptXJ85EaxwZw==",
       "requires": {
         "@polymer/polymer": "^3.4.1",
         "dexie": "^3.0.1",
@@ -1795,15 +1780,14 @@
       }
     },
     "@unicef-polymer/etools-content-panel": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-content-panel/-/etools-content-panel-4.0.1.tgz",
-      "integrity": "sha512-fJWk5uoGPokkJF6dWbmySCyYqeYlTrMRWVH0t+HY117sHLkpHw216yDI88hgXY/J2W/mcCIhlCFkE13piV5Pxg==",
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-content-panel/-/etools-content-panel-5.0.0-rc.2.tgz",
+      "integrity": "sha512-A+TdOLwGLn6b9/XgtwNUFRuTxnBhltHcnWzeo6+89witryKsE5ed9+N5GA863RobPY//4LgrjpOveBANjloIsw==",
       "requires": {
         "@polymer/iron-collapse": "^3.0.1",
-        "@polymer/iron-flex-layout": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",
-        "@polymer/paper-styles": "^3.0.1",
-        "@polymer/polymer": "^3.4.1"
+        "@polymer/polymer": "^3.4.1",
+        "lit-element": "^2.3.1"
       }
     },
     "@unicef-polymer/etools-date-time": {
@@ -1836,9 +1820,9 @@
       }
     },
     "@unicef-polymer/etools-dialog": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-dialog/-/etools-dialog-4.3.0.tgz",
-      "integrity": "sha512-LIAC9cDWvqhtamML1BuoUjgMfOFVJePnxoDJX5FmC6y0o04SynObM/KiUg8heI28m/8PeeRL4ForiOF3KaKidA==",
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-dialog/-/etools-dialog-5.0.0-rc.2.tgz",
+      "integrity": "sha512-Je3Kl0bvpZMBrXLEQNv8u6hxd8/zi2QIsKMKetcYhxtWryy2Z9vMPliM5rCZtihf7TLsT4y36ufRvUcEWEnwkA==",
       "requires": {
         "@a11y/focus-trap": "^1.0.5",
         "@polymer/iron-icon": "^3.0.0",
@@ -1849,15 +1833,15 @@
         "@polymer/paper-icon-button": "^3.0.0",
         "@polymer/polymer": "^3.4.1",
         "@unicef-polymer/etools-behaviors": "^3.0.2",
-        "@unicef-polymer/etools-loading": "^4.0.4",
+        "@unicef-polymer/etools-loading": "5.0.0-rc.2",
         "lodash-es": "^4.17.20",
         "web-animations-js": "^2.3.2"
       }
     },
     "@unicef-polymer/etools-dropdown": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-dropdown/-/etools-dropdown-3.5.0.tgz",
-      "integrity": "sha512-Nc9ZrDPsr3dWgyFPS3rV6DEov4bQmc2wtgWMNJZzK+G98lAg8wRutObdDLYFHJf94gJ4BvKirUtQl1oPOI09qg==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-dropdown/-/etools-dropdown-3.7.7.tgz",
+      "integrity": "sha512-ay6+FnEqkA1tFUTPBXDCfjH7ciNIU/Ei6XSfKTrTklkMGyEr+q0zcBZpyeNDOkQsfhwcgdDjigVzg4HoeoIkZg==",
       "requires": {
         "@polymer/iron-dropdown": "^3.0.0",
         "@polymer/iron-flex-layout": "^3.0.0",
@@ -1873,46 +1857,33 @@
         "@polymer/polymer": "^3.4.1",
         "@unicef-polymer/etools-ajax": "^4.2.0",
         "@unicef-polymer/etools-behaviors": "^3.0.4",
-        "@unicef-polymer/etools-loading": "^4.0.4",
-        "acorn": "^8.0.5",
-        "diff": "^5.0.0",
-        "growl": ">=1.10.0",
         "lodash": ">=4.17.21",
-        "lodash-es": "^4.17.21",
-        "minimist": ">=0.2.1",
-        "prismjs": ">=1.21.0",
+        "lodash-es": ">=4.17.21",
         "web-animations-js": "^2.3.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
       }
     },
     "@unicef-polymer/etools-loading": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-loading/-/etools-loading-4.0.4.tgz",
-      "integrity": "sha512-O/J/RL3W0VWdMLFWPvcjoQS4jYvUTYOmh0vNYPTeGqLruvIs3VxiE1J+zXKcPmLtrKc4rHCmBwRKxHQzgvmpaw==",
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-loading/-/etools-loading-5.0.0-rc.2.tgz",
+      "integrity": "sha512-ezfBYVpQ61T4jgkvCEsBhA3RYAo6jhQZRqmBk6lmGRrJZ3gN+AfoN5q9fqUEiMlufGpNMjdBkSzQcr5X1hXpeg==",
       "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0",
-        "@polymer/iron-test-helpers": "^3.0.0",
         "@polymer/paper-spinner": "^3.0.0",
         "@polymer/polymer": "^3.4.1",
-        "lit-element": "^2.3.1",
-        "lodash-es": "^4.17.15"
+        "lit-element": "^2.3.1"
+      }
+    },
+    "@unicef-polymer/etools-piwik-analytics": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-piwik-analytics/-/etools-piwik-analytics-3.0.2.tgz",
+      "integrity": "sha512-77e2wmrfSDPfhyaFD9/a/SoJRQxz+PQmSm9RSs0CtISGARD3RWXXAb6vk7Ez0ApV2lc5UHaE9eAgggzLyFZ3vg==",
+      "requires": {
+        "@polymer/polymer": "^3.4.1"
       }
     },
     "@unicef-polymer/etools-profile-dropdown": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-profile-dropdown/-/etools-profile-dropdown-5.0.4.tgz",
-      "integrity": "sha512-Qd631Fz60P6dK7l5vAhwF2pSvKKNA6SHXEZzaEQisJBr4mGW96FR3cF/psmeCceuMUefJN6CstHUXTHonBl6tw==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-profile-dropdown/-/etools-profile-dropdown-6.0.0-rc.1.tgz",
+      "integrity": "sha512-IvH7IJSRTzpB0uROCHnlNiVergHClXxVpXWgayCxGXeMHeRvAh9AuCTFGOe0yNRrcwCp+BgTFwLzZQADObW43Q==",
       "requires": {
         "@polymer/iron-dropdown": "^3.0.0",
         "@polymer/iron-icons": "^3.0.0",
@@ -1921,30 +1892,26 @@
         "@polymer/paper-styles": "^3.0.0",
         "@polymer/polymer": "^3.4.1",
         "@unicef-polymer/etools-ajax": "^4.2.0",
-        "@unicef-polymer/etools-behaviors": "^3.0.4",
-        "@unicef-polymer/etools-dialog": "^4.2.1",
-        "@unicef-polymer/etools-dropdown": "^3.3.0",
-        "@unicef-polymer/etools-loading": "^4.0.4",
-        "lodash-es": "^4.17.20"
+        "@unicef-polymer/etools-dialog": "5.0.0-rc.2"
       }
     },
     "@unicef-polymer/etools-table": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-table/-/etools-table-1.2.1.tgz",
-      "integrity": "sha512-kmB3ZcIdQq5AZB4vZPEa80cXdd6yylM0stO3+uYuXfNggFQALs0ivOpy/WmP17xzJdJQM1Isj2AcE5/TadbkIA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-table/-/etools-table-1.3.0.tgz",
+      "integrity": "sha512-DVpY+4m2N2Zm6gjTRQjrPZklub8/qYKf3MV19rl9n4ly97h8+wK/ym0/nGbc22QUlks3hJtGTZzqIfCIqJVbjA==",
       "requires": {
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-checkbox": "^3.1.0",
         "@polymer/paper-icon-button": "^3.0.2",
         "@polymer/polymer": "^3.4.1",
         "lit-element": "^2.4.0",
-        "lodash-es": "^4.17.20"
+        "lodash-es": "^4.17.21"
       }
     },
     "@unicef-polymer/etools-upload": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-upload/-/etools-upload-3.5.0.tgz",
-      "integrity": "sha512-kW57ZSWaCtgExlYqQqxn4RYFBXcbVOMbzpdrKnXL66bTcIGeOJtmwEF7h0RMIsrYOZv1o8ucyb9NkoEOV7jEPw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@unicef-polymer/etools-upload/-/etools-upload-3.5.2.tgz",
+      "integrity": "sha512-wF7UZ2H4JyVZ2oK6E3Pns0sfVTBvRQSpxGwLKNI64/FVQxDAZKkZIMuBFBe1aSBhOG0bnWM4TrdKZFkPrf79mw==",
       "requires": {
         "@polymer/iron-flex-layout": "^3.0.1",
         "@polymer/iron-icon": "^3.0.1",
@@ -1956,15 +1923,8 @@
         "@unicef-polymer/etools-ajax": "^4.2.0",
         "@webcomponents/webcomponentsjs": "^2.5.0",
         "dexie": "^3.0.3",
-        "lodash": "^4.17.20",
+        "lodash": ">=4.17.21",
         "web-animations-js": "^2.3.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
       }
     },
     "@webcomponents/shadycss": {
@@ -2656,6 +2616,16 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "body-parser": {
@@ -3566,11 +3536,6 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.3.tgz",
       "integrity": "sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw=="
     },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4243,6 +4208,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -4410,6 +4382,17 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4628,7 +4611,8 @@
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "gulp-if": {
       "version": "2.0.2",
@@ -5645,8 +5629,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -5982,7 +5965,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -6117,6 +6101,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10040,15 +10031,6 @@
             "is-glob": "^2.0.0",
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0"
-          },
-          "dependencies": {
-            "fsevents": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-              "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "chownr": {
@@ -20845,11 +20827,6 @@
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -22389,7 +22366,8 @@
     "ua-parser-js": {
       "version": "0.7.28",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -50,17 +50,18 @@
     "@polymer/polymer": "^3.4.1",
     "@types/lodash-es": "^4.17.3",
     "@unicef-polymer/etools-ajax": "^4.2.0",
-    "@unicef-polymer/etools-app-selector": "^3.1.6",
+    "@unicef-polymer/etools-app-selector": "^3.1.8",
     "@unicef-polymer/etools-behaviors": "^3.0.4",
-    "@unicef-polymer/etools-content-panel": "^4.0.1",
+    "@unicef-polymer/etools-content-panel": "5.0.0-rc.2",
     "@unicef-polymer/etools-date-time": "^2.2.1",
     "@unicef-polymer/etools-dexie-caching": "^1.0.2",
-    "@unicef-polymer/etools-dialog": "^4.3.0",
-    "@unicef-polymer/etools-dropdown": "^3.5.0",
-    "@unicef-polymer/etools-loading": "^4.0.4",
-    "@unicef-polymer/etools-profile-dropdown": "^5.0.4",
+    "@unicef-polymer/etools-dialog": "5.0.0-rc.2",
+    "@unicef-polymer/etools-dropdown": "^3.7.1",
+    "@unicef-polymer/etools-loading": "5.0.0-rc.2",
+    "@unicef-polymer/etools-profile-dropdown": "6.0.0-rc.1",
     "@unicef-polymer/etools-table": "^1.2.1",
     "@unicef-polymer/etools-upload": "^3.5.0",
+    "@unicef-polymer/etools-piwik-analytics": "^3.0.2",
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "dayjs": "^1.10.6",
     "lit-element": "^2.5.1",
@@ -69,7 +70,6 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "ua-parser-js": ">=0.7.24",
     "web-animations-js": "^2.3.2"
   },
   "devDependencies": {
@@ -96,7 +96,8 @@
     "prettier": "^2.0.5",
     "prpl-server": "^1.3.0",
     "typescript": "^3.1.3",
-    "wct-mocha": "^1.1.0"
+    "wct-mocha": "^1.1.0",
+    "ua-parser-js": ">=0.7.24"
   },
   "husky": {
     "hooks": {

--- a/src_ts/components/app-shell/app-shell.ts
+++ b/src_ts/components/app-shell/app-shell.ts
@@ -24,6 +24,7 @@ import '@polymer/app-layout/app-drawer/app-drawer.js';
 import '@polymer/app-layout/app-header-layout/app-header-layout.js';
 import '@polymer/app-layout/app-header/app-header.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
+import '@unicef-polymer/etools-piwik-analytics/etools-piwik-analytics';
 import {createDynamicDialog} from '@unicef-polymer/etools-dialog/dynamic-dialog';
 
 import {AppDrawerLayoutElement} from '@polymer/app-layout/app-drawer-layout/app-drawer-layout';
@@ -42,7 +43,7 @@ import {ToastNotificationHelper} from '../common/toast-notifications/toast-notif
 import user from '../../redux/reducers/user';
 import commonData from '../../redux/reducers/common-data';
 import pageData from '../../redux/reducers/page-data';
-import {setLoggingLevel, SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY} from '../../config/config';
+import {ROOT_PATH, setLoggingLevel, SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY} from '../../config/config';
 import {getCurrentUser} from '../user/user-actions';
 import {EtoolsRouter} from '../../routing/routes';
 import {RouteDetails} from '../../routing/router';
@@ -82,6 +83,13 @@ export class AppShell extends connect(store)(LitElement) {
     // main template
     // language=HTML
     return html`
+      <etools-piwik-analytics
+        .page="${ROOT_PATH + this.mainPage}"
+        .user="${this.user}"
+        .toast="${this.currentToastMessage}"
+      >
+      </etools-piwik-analytics>
+
       <app-drawer-layout
         id="layout"
         responsive-width="850px"
@@ -110,7 +118,7 @@ export class AppShell extends connect(store)(LitElement) {
         <!-- Main content -->
         <app-header-layout id="appHeadLayout" fullbleed has-scrolling-region>
           <app-header slot="header" fixed shadow>
-            <page-header id="pageheader" title="eTools"></page-header>
+            <page-header id="pageheader"></page-header>
           </app-header>
 
           <!-- Main content -->
@@ -158,6 +166,12 @@ export class AppShell extends connect(store)(LitElement) {
   @property({type: Boolean})
   public smallMenu = false;
 
+  @property({type: Object})
+  user!: any;
+
+  @property({type: String})
+  currentToastMessage!: string;
+
   @query('#layout') private drawerLayout!: AppDrawerLayoutElement;
   @query('#drawer') private drawer!: AppDrawerElement;
   @query('#appHeadLayout') private appHeaderLayout!: AppHeaderLayoutElement;
@@ -172,7 +186,7 @@ export class AppShell extends connect(store)(LitElement) {
     // preventable, allowing for better scrolling performance.
     setPassiveTouchGestures(true);
     // init toasts notifications queue
-    this.appToastsNotificationsHelper = new ToastNotificationHelper();
+    this.appToastsNotificationsHelper = new ToastNotificationHelper(this);
     this.appToastsNotificationsHelper.addToastNotificationListeners();
 
     const menuTypeStoredVal: string | null = localStorage.getItem(SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY);
@@ -185,6 +199,7 @@ export class AppShell extends connect(store)(LitElement) {
     checkEnvFlags().then((response) => {
       if (!this._pseaIsDisabled(response)) {
         getCurrentUser().then((user) => {
+          this.user = user;
           if (user && user.is_unicef_user) {
             store.dispatch(loadExternalIndividuals());
             store.dispatch(loadAssessingFirms());

--- a/src_ts/components/app-shell/app-theme.ts
+++ b/src_ts/components/app-shell/app-theme.ts
@@ -5,7 +5,7 @@ const documentContainer = document.createElement('template');
 documentContainer.innerHTML = `
   <custom-style>
     <style>
-      html {
+      .default {
         --primary-color: #0099ff;
         --primary-background-color: #FFFFFF;
         --secondary-background-color: #eeeeee;
@@ -33,6 +33,7 @@ documentContainer.innerHTML = `
         --primary-shade-of-green: #1A9251;
         --primary-shade-of-red: #E32526;
         --primary-shade-of-orange: orange;
+        --text-color-on-orange: #ffffff;
 
         --primary-shade-of-darkorange: darkorange;
 
@@ -42,45 +43,91 @@ documentContainer.innerHTML = `
         --warning-color: #856404;
         --warning-border-color: #ffeeba;
 
-        --error-box-heading-color: var(--error-color);
-        --error-box-bg-color: #f2dede;
-        --error-box-border-color: #ebccd1;
-        --error-box-text-color: var(--error-color);
-
-        --ecp-header-color: var(--primary-text-color);
-
-        --paper-input-container-label: {
-          color: var(--secondary-text-color, #737373);
-        }
-        --paper-input-container-label-floating: {
-          color: var(--secondary-text-color, #737373);
-        }
-        --paper-input-prefix: {
-          color: var(--secondary-text-color, #737373);
-          margin-right: 10px;
-        };
-        --esmm-external-wrapper: {
-          width: 100%;
-          margin: 0;
-        };
-        --paper-checkbox-checked-color: var(--primary-color);
-        --paper-checkbox-unchecked-color: var(--secondary-text-color);
-        --paper-radio-button-checked-color: var(--primary-color);
-        --paper-radio-button-unchecked-color: var(--secondary-text-color);
-
-        --paper-button-flat-keyboard-focus: {
-          outline: 0;
-          box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12),
-           0 3px 5px -1px rgba(0, 0, 0, 0.4);
-        }
-
-        --paper-button-raised-keyboard-focus: {
-          outline: 0;
-          box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12),
-           0 3px 5px -1px rgba(0, 0, 0, 0.4);
-        }    
-
+        --paper-label-font-size: 12px;
+        --input-label-font-size: 16px;
       }
+      .accessible {
+        --primary-color: #005E9E;
+        --primary-background-color: #FFFFFF;
+        --secondary-background-color: #eeeeee;
+
+        --primary-text-color: rgba(0, 0, 0, 0.87);
+        --secondary-text-color: rgba(0, 0, 0, 0.74);
+
+        --header-color: #ffffff;
+        --header-bg-color: #233944;
+        --header-icon-color: rgba(250, 250, 250, 0.90);
+        --nonprod-header-color: #662929;
+        --nonprod-text-warn-color: #e6e600;
+
+        --light-divider-color: rgba(0, 0, 0, 0.12);
+        --dark-divider-color: rgba(0, 0, 0, 0.40);
+
+        --dark-icon-color: rgba(0, 0, 0, 0.65);
+        --light-icon-color: rgba(255, 255, 255, 1);
+
+        --side-bar-scrolling: visible;
+
+        --success-color: #72c300;
+        --error-color: #ea4022;
+
+        --primary-shade-of-green: #04632C;
+        --primary-shade-of-red: #AA1D24;
+        --primary-shade-of-orange: orange;
+        --text-color-on-orange: #002A3F;
+
+        --primary-shade-of-darkorange: darkorange;
+
+        --info-color: #cebc06;
+        --light-info-color: #fff176;
+        --warning-background-color: #fff3cd;
+        --warning-color: #856404;
+        --warning-border-color: #ffeeba;
+
+        --paper-label-font-size: 14px;
+        --input-label-font-size: 18px;
+        --etools-table-secondary-text-color: rgba(0, 0, 0, 0.74);
+      }
+      html {
+      --error-box-heading-color: var(--error-color);
+      --error-box-bg-color: #f2dede;
+      --error-box-border-color: #ebccd1;
+      --error-box-text-color: var(--error-color);
+
+      --ecp-header-color: var(--primary-text-color);
+
+      --paper-input-container-label: {
+        color: var(--secondary-text-color, #737373);
+      }
+      --paper-input-container-label-floating: {
+        color: var(--secondary-text-color, #737373);
+      }
+      --paper-input-prefix: {
+        color: var(--secondary-text-color, #737373);
+        margin-right: 10px;
+      };
+
+      --esmm-external-wrapper: {
+        width: 100%;
+        margin: 0;
+      };
+      --paper-checkbox-checked-color: var(--primary-color);
+      --paper-checkbox-unchecked-color: var(--secondary-text-color);
+      --paper-radio-button-checked-color: var(--primary-color);
+      --paper-radio-button-unchecked-color: var(--secondary-text-color);
+
+      --paper-button-flat-keyboard-focus: {
+        outline: 0;
+        box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12),
+          0 3px 5px -1px rgba(0, 0, 0, 0.4);
+      }
+
+      --paper-button-raised-keyboard-focus: {
+        outline: 0;
+        box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12),
+          0 3px 5px -1px rgba(0, 0, 0, 0.4);
+      }
+    }
     </style>
   </custom-style>`;
 

--- a/src_ts/components/app-shell/header/page-header.ts
+++ b/src_ts/components/app-shell/header/page-header.ts
@@ -53,9 +53,10 @@ export class PageHeader extends connect(store)(LitElement) {
         <div class="content-align">
           <countries-dropdown></countries-dropdown>
 
-          <support-btn></support-btn>
+          <support-btn title="Support"></support-btn>
 
           <etools-profile-dropdown
+            title="Profile and Sign out"
             .sections="${this.profileDrSections}"
             .offices="${this.profileDrOffices}"
             .users="${this.profileDrUsers}"

--- a/src_ts/components/app-shell/menu/app-menu.ts
+++ b/src_ts/components/app-shell/menu/app-menu.ts
@@ -3,10 +3,16 @@ import '@polymer/iron-icons/maps-icons.js';
 import '@polymer/iron-selector/iron-selector.js';
 import '@polymer/paper-tooltip/paper-tooltip.js';
 import '@polymer/paper-ripple/paper-ripple.js';
+import '@polymer/paper-toggle-button/paper-toggle-button';
+import {PaperToggleButtonElement} from '@polymer/paper-toggle-button';
 import {pseaIcon} from '../../styles/app-icons';
 import {navMenuStyles} from './styles/nav-menu-styles';
 import {fireEvent} from '../../utils/fire-custom-event';
-import {ROOT_PATH, SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY} from '../../../config/config';
+import {
+  ACCESIBILITY_MODE_LOCALSTORAGE_KEY,
+  ROOT_PATH,
+  SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY
+} from '../../../config/config';
 import {customElement, html, LitElement, property} from 'lit-element';
 
 /**
@@ -63,6 +69,22 @@ export class AppMenu extends LitElement {
         </iron-selector>
 
         <div class="nav-menu-item section-title">
+          <span>Accesibility Tools</span>
+        </div>
+        <div class="pnl-toggle">
+          <paper-tooltip for="toggleTheme" offset="0" position="right" ?hidden="${!this.smallMenu}">
+            Increase Text Contrast
+          </paper-tooltip>
+          <paper-toggle-button
+            id="toggleTheme"
+            ?checked="${this.isAccessibilityTheme}"
+            @iron-change="${this.toggleTheme}"
+          >
+            ${this.getToggleText(this.smallMenu)}
+          </paper-toggle-button>
+        </div>
+
+        <div class="nav-menu-item section-title">
           <span>eTools Community Channels</span>
         </div>
 
@@ -100,10 +122,45 @@ export class AppMenu extends LitElement {
   @property({type: Boolean, attribute: 'small-menu'})
   public smallMenu = false;
 
+  @property({type: Boolean})
+  isAccessibilityTheme = false;
+
+  public connectedCallback() {
+    super.connectedCallback();
+
+    this.isAccessibilityTheme = localStorage.getItem(ACCESIBILITY_MODE_LOCALSTORAGE_KEY) === 'true';
+    this.setAppTheme();
+  }
+
   public _toggleSmallMenu(): void {
     this.smallMenu = !this.smallMenu;
     const localStorageVal: number = this.smallMenu ? 1 : 0;
     localStorage.setItem(SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY, String(localStorageVal));
     fireEvent(this, 'toggle-small-menu', {value: this.smallMenu});
+  }
+
+  protected toggleTheme(e: any) {
+    const isAccessibilityTheme = (e.target as PaperToggleButtonElement).checked;
+    if (this.isAccessibilityTheme !== isAccessibilityTheme) {
+      this.isAccessibilityTheme = !this.isAccessibilityTheme;
+      localStorage.setItem(ACCESIBILITY_MODE_LOCALSTORAGE_KEY, String(this.isAccessibilityTheme));
+      this.setAppTheme();
+    }
+  }
+
+  private setAppTheme() {
+    const body = document.body;
+
+    if (this.isAccessibilityTheme) {
+      body.classList.remove('default');
+      body.classList.add('accessible');
+    } else {
+      body.classList.remove('accessible');
+      body.classList.add('default');
+    }
+  }
+
+  private getToggleText(smallMenu: boolean) {
+    return smallMenu ? '' : ' Increase Text Contrast';
   }
 }

--- a/src_ts/components/app-shell/menu/styles/nav-menu-styles.ts
+++ b/src_ts/components/app-shell/menu/styles/nav-menu-styles.ts
@@ -188,4 +188,10 @@ export const navMenuStyles = css`
   .ripple-wrapper {
     position: relative;
   }
+
+  .pnl-toggle {
+    margin: 0 auto;
+    margin-top: 12px;
+    margin-bottom: 20px;
+  }
 `;

--- a/src_ts/components/common/toast-notifications/toast-notification-helper.ts
+++ b/src_ts/components/common/toast-notifications/toast-notification-helper.ts
@@ -1,6 +1,7 @@
 import {EtoolsToast} from './etools-toast';
 import './etools-toast'; // element loaded (if not, etools-toast will not render)
 import {GenericObject} from '../../../types/globals';
+import {AppShell} from '../../app-shell/app-shell';
 
 /**
  * Toasts notification messages queue utility class
@@ -9,8 +10,10 @@ export class ToastNotificationHelper {
   private readonly _toast: EtoolsToast;
   private _toastQueue: GenericObject[] = [];
   private TOAST_EL_ID = 'toastNotificationQueueEl';
+  private appShellEl!: AppShell;
 
-  constructor() {
+  constructor(appShellEl: AppShell) {
+    this.appShellEl = appShellEl;
     const toast = document.querySelector(this.TOAST_EL_ID) as EtoolsToast;
     this._toast = toast ? toast : this.createToastNotificationElement();
   }
@@ -85,8 +88,7 @@ export class ToastNotificationHelper {
   }
 
   protected _showToast(toastProperties: GenericObject) {
-    // TODO: currentToastMessage is used by piwik elem; use it or remove it :)
-    // this.appShellEl.set('currentToastMessage', toastProperties.text);
+    this.appShellEl.currentToastMessage = toastProperties.text;
     this._toast.show(toastProperties);
   }
 }

--- a/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
@@ -108,7 +108,8 @@ export class FollowUpDialog extends connect(store)(LitElement) {
             value="${this.editedItem.description}"
             label="Description"
             max-rows="4"
-            auto-validate
+            @focus="${() => (this.autoValidate = true)}"
+            .autoValidate="${this.autoValidate}"
           >
           </paper-textarea>
         </div>
@@ -232,6 +233,9 @@ export class FollowUpDialog extends connect(store)(LitElement) {
 
   @property({type: Boolean})
   requestInProcess = false;
+
+  @property({type: Boolean})
+  autoValidate = false;
 
   @property({type: Boolean})
   isNewRecord = true;

--- a/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
@@ -78,6 +78,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               option-label="name"
               option-value="id"
               ?readOnly="${this.editedItem.partner}"
+              auto-validate
             >
             </etools-dropdown>
           </div>
@@ -91,6 +92,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               option-label="reference_number"
               option-value="id"
               ?readOnly="${this.assessment.id}"
+              auto-validate
             >
             </etools-dropdown>
           </div>
@@ -106,6 +108,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
             value="${this.editedItem.description}"
             label="Description"
             max-rows="4"
+            auto-validate
           >
           </paper-textarea>
         </div>
@@ -120,6 +123,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               option-label="name"
               required
               option-value="id"
+              auto-validate
             >
             </etools-dropdown>
           </div>
@@ -133,6 +137,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               option-label="name"
               required
               option-value="id"
+              auto-validate
             >
             </etools-dropdown>
           </div>
@@ -148,6 +153,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               option-label="name"
               required
               option-value="id"
+              auto-validate
             >
             </etools-dropdown>
           </div>
@@ -159,6 +165,7 @@ export class FollowUpDialog extends connect(store)(LitElement) {
               label="Due Date"
               required
               selected-date-display-format="D MMM YYYY"
+              auto-validate
             >
             </datepicker-lite>
           </div>

--- a/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/follow-up/follow-up-dialog.ts
@@ -186,11 +186,11 @@ export class FollowUpDialog extends connect(store)(LitElement) {
   };
 
   private validationSelectors: string[] = [
-    '#categoryInput',
+    '#descriptionInput',
     '#assignedToInput',
     '#sectionInput',
     '#officeInput',
-    '#dateInput'
+    '#dueDateInput'
   ];
 
   @property({type: Array})
@@ -297,7 +297,6 @@ export class FollowUpDialog extends connect(store)(LitElement) {
   }
 
   private getControlsData() {
-    // this.editedItem.category = this.getEl('#categoryInput').selected;
     // @ts-ignore
     this.editedItem.assigned_to = this.getEl('#assignedToInput').selected;
     // @ts-ignore

--- a/src_ts/components/pages/assessments/assessment-tab-pages/questionnaire/assessment-questionnaire-page.ts
+++ b/src_ts/components/pages/assessments/assessment-tab-pages/questionnaire/assessment-questionnaire-page.ts
@@ -61,6 +61,7 @@ export class AssessmentQuestionnairePage extends connect(store)(LitElement) {
         }
         .orange {
           background-color: var(--primary-shade-of-orange);
+          color: var(--text-color-on-orange);
         }
         .green {
           background-color: var(--primary-shade-of-green);

--- a/src_ts/components/styles/label-and-value-styles-lit.ts
+++ b/src_ts/components/styles/label-and-value-styles-lit.ts
@@ -3,7 +3,7 @@ import {css} from 'lit-element';
 // language=HTML
 export const labelAndvalueStylesLit = css`
   .paper-label {
-    font-size: 12px;
+    font-size: var(--paper-label-font-size);
     color: var(--secondary-text-color);
     padding-top: 6px;
   }

--- a/src_ts/components/styles/shared-styles-lit.ts
+++ b/src_ts/components/styles/shared-styles-lit.ts
@@ -124,9 +124,11 @@ export const SharedStylesLit = html`
     etools-currency-amount-input {
       --paper-input-container-label: {
         color: var(--secondary-text-color, #737373);
+        font-size: var(--input-label-font-size);
       }
       --paper-input-container-label-floating: {
         color: var(--secondary-text-color, #737373);
+        font-size: var(--input-label-font-size);
       }
       --paper-input-container-input: {
         display: block;
@@ -144,10 +146,12 @@ export const SharedStylesLit = html`
       --paper-input-container-label: {
         @apply --required-star-style;
         color: var(--secondary-text-color, #737373);
+        font-size: var(--input-label-font-size);
       }
       --paper-input-container-label-floating: {
         @apply --required-star-style;
         color: var(--secondary-text-color, #737373);
+        font-size: var(--input-label-font-size);
       }
     }
 

--- a/src_ts/config/config.ts
+++ b/src_ts/config/config.ts
@@ -11,6 +11,7 @@ const DEV_DOMAIN = 'etools-dev.unicef.org';
 const DEMO_DOMAIN = 'etools-demo.unicef.org';
 
 export const SMALL_MENU_ACTIVE_LOCALSTORAGE_KEY = 'etoolsAppSmallMenuIsActive';
+export const ACCESIBILITY_MODE_LOCALSTORAGE_KEY = 'etoolsAppAccesibilityModeIsActive';
 export const ROOT_PATH = '/psea/';
 
 export const isProductionServer = () => {


### PR DESCRIPTION
* [ch24553] moment.js is deprecated, time for an alternative (#293)

* Remove page refresh after save attachments (#295)

* fixed border issue on paper inputs

* [ch24746] Background is not entirely blurred when saving sections on form (#296)

* Update components version (#299)

* Update components version

* update versions

* update packages

Co-authored-by: Adriana Trif <trif.corina.adriana@gmail.com>

* [ch24978] 'Loading..' display issue (#301)

* [ch24978] 'Loading..' display issue

* adjustments

* [ch25003] Fix filters layout (dropdown options, add labels for filters, highlight selected filters, fix datepicker position, `Add filters` and `Show completed` borders) (#304)

* [ch18403] Add more details to the PSEA details screen. (#305)

* [ch24961] Update all apps to use the new version of @unicef-polymer packages that make use of CSS Shadow Parts (#302)

* [ch24961] Update all apps to use the new version of @unicef-polymer packages that make use of CSS Shadow Parts

* adjustments

* updated versions

* [ch25128] Previous navigation view is kept on a new assessment questionnaire (#307)

* [ch25128] Previous navigation view is kept on a new assessment questionnaire

* adjustments

* [ch25257] Standardize Clear all action: remove filters from UI and deselect selected filters from the dropdown (#308)

* Filter by Sea Risk Ratings (#303)

* SEA Risk Rating filter (#309)

* [ch25663] Firm Name not displayed when logged in with Firm Staff Member with Access (#311)

* Update packages, tweaks (#313)

* [ch25723] PSEA: Edit icon on Action Points should no longer be available if Status = "completed" (#314)

* [ch25723] PSEA: Edit icon on Action Points should no longer be available if Status = "completed" (#315)

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021 (#316)

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021

* adjustments

* [ch25785] Invalid message displayed premature at dialog open (#318)

* [ch25785] Invalid message displayed premature at dialog open

* adjustments

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021 (#319)

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021

* fix

* Responsive status (#320)

* Arrow to right when left side menu minimized (#321)

* [ch21780] adding additional columns for the export excel sheet of individual assessments

* [ch21780] adding additional columns for the export excel sheet of individual assessments (#322)

* Refactoring (#323)

* Fromat msg to be understood eaier

* Refactor to eliminate the need for toastEventSource

* Clean up toastEventSource

* [ch25659]Add possibility to attach NFR (#324)

* Fromat msg to be understood eaier

* Refactor to eliminate the need for toastEventSource

* NFR attachment

* clean up

* Clean up toastEventSource

* clean up

* update packages

* Display NFR att

* display nfr att

* fix console err

* fix console err

* fix console err

* update app-sel (#326)

* [ch26022] Simplify how dialogs are used (use openDialog method) (#328)

* [ch21780] adding additional columns for the export excel sheet of individual assessments

* [ch26022] Simplify how dialogs are used (use openDialog method)

* adjustments

* adjustments

* adjustments

* [ch26169] Fix datepicker overlay to open above dialogs (like dropdowns)

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021 (#331)

* [ch21780] adding additional columns for the export excel sheet of individual assessments

* [ch25658] Add 2 new dropdown menus "PSEA assessment type" and "Reason for country-level INGO assessment" to match changes in VISION for 1 July 2021

* adjustments

* [ch26256] Update etools-dropdown in all apps (to make the infinite scroll functionality available)

* [ch15943] Reason for rejection should disappear once the Assessment is in status "Final" (#335)

* [ch26249]Notify the user to refresh page when a new version of the app has been deployed (#334)

* [ch21780] adding additional columns for the export excel sheet of individual assessments

* [ch26249]Notify the user to refresh page when a new version of the app has been deployed

* [ch26374] Update etools-dropdown, etools-date-time versions (#337)

* [ch26483]Save and Cancel btns still available at submission of Questionnaire if a Core Standard section is open (#339)

* Fix save/cancel visibility after submit

* Add keyboard focus styles for paper-button

* Reset UI

* Reset UI

* Fix open not working

* [ch26542]PSEA - datepicker cut off on smaller screen heights (#340)

* Fix save/cancel visibility after submit

* Add keyboard focus styles for paper-button

* Reset UI

* Reset UI

* Move & update datepicker

* undo

* Add accessibility doc (#342)

* [ch26829] Clean up index.html (#346)

* [ch26829] Clean up index.html

* [ch26829] Clean up index.html

* [ch26772]Use node 12 in circleci and Dockerfiles, packages&config clean up (#343)

* Circleci tweak

* prettier fixes

* eslint fixes

* eslint fixes

* eslint fix

* config

* dockerignore

* package-lock

* tweak

* gulp clean up

* tweak

* Update README.md

* tweak

* Piwik tracking for toast notifs (#350)

* [ch26572] [Accessibility]Ensure that all text contrasts sufficiently with its background when viewed by (#349)

* [ch26572] [Accessibility]Ensure that all text contrasts sufficiently with its background when viewed by

* formatting

Co-authored-by: Trif Adriana <trif.corina.adriana@gmail.com>

* [ch26572] [Accessibility] Ensure that all text contrasts sufficiently with its background when viewed by (#353)

* [ch26841]Use LitElem etools-loading, content-panel (#352)

* Use LitElem etools-loading, content-panel

* Use LitElem etools-loading, content-panel

* build img

* Update config.yml

* [ch27584] Incorrect Date validation for "Due on" (#354)

* [ch27671] Update tooltip text when hovering over app selector, Support link, user profile, refresh symbol (#355)

* [ch27671] Update tooltip text when hovering over app selector, Support link, user profile, refresh symbol

* updated app-selector version

Co-authored-by: Dan <49279861+danNordlogic@users.noreply.github.com>
Co-authored-by: Lazar Andrei <lazaryandrei@gmail.com>
Co-authored-by: dcioara <dan.cioara@nordlogic.com>